### PR TITLE
fix: string types for metadata and signature

### DIFF
--- a/src/util/construction.ts
+++ b/src/util/construction.ts
@@ -7,7 +7,7 @@ import { promptUser } from './signing';
 
 /* Types */
 
-type Signature = `0x$string`;
+type Signature = `0x${string}`;
 
 interface BaseTxInfo {
   address: string;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -4,7 +4,7 @@ import { TypeRegistry } from '@polkadot/types';
 export type ChainName = 'Polkadot' | 'Polkadot CC1' | 'Kusama' | 'Westend';
 export type SpecName = 'polkadot' | 'kusama' | 'westend';
 export type Curve = 'sr25519' | 'ed25519' | 'ecdsa';
-export type Metadata = `0x$string` | `0x${string}`;
+export type Metadata = `0x${string}`;
 
 // Information about the chain that we need to construct a transaction.
 export interface ChainData {


### PR DESCRIPTION
This changes or removes any types associated as `0x$string`.